### PR TITLE
image_type_phosphor: allow overriding the bootloader

### DIFF
--- a/classes/image_types_phosphor.bbclass
+++ b/classes/image_types_phosphor.bbclass
@@ -49,6 +49,7 @@ INSECURE_KEY = "${@'${SIGNING_KEY}' == '${STAGING_DIR_NATIVE}${datadir}/OpenBMC.
 SIGNING_KEY_DEPENDS = "${@oe.utils.conditional('INSECURE_KEY', 'True', 'phosphor-insecure-signing-key-native:do_populate_sysroot', '', d)}"
 
 UBOOT_SUFFIX ?= "bin"
+FLASH_UBOOT_IMAGE ?= "u-boot.${UBOOT_SUFFIX}"
 
 python() {
     # Compute rwfs LEB count and LEB size.
@@ -166,7 +167,7 @@ do_make_ubi() {
 	# Concatenate the uboot and ubi partitions
 	mk_nor_image ${IMGDEPLOYDIR}/${IMAGE_NAME}.ubi.mtd ${FLASH_SIZE}
 	dd bs=1k conv=notrunc seek=${FLASH_UBOOT_OFFSET} \
-		if=${DEPLOY_DIR_IMAGE}/u-boot.${UBOOT_SUFFIX} \
+		if=${DEPLOY_DIR_IMAGE}/${FLASH_UBOOT_IMAGE} \
 		of=${IMGDEPLOYDIR}/${IMAGE_NAME}.ubi.mtd
 	dd bs=1k conv=notrunc seek=${FLASH_UBI_OFFSET} \
 		if=ubi-img \
@@ -207,7 +208,7 @@ python do_generate_static() {
                                'of=%s' % nor_image])
 
     _append_image(os.path.join(d.getVar('DEPLOY_DIR_IMAGE', True),
-                               'u-boot.%s' % d.getVar('UBOOT_SUFFIX',True)),
+                               d.getVar('FLASH_UBOOT_IMAGE',True)),
                   int(d.getVar('FLASH_UBOOT_OFFSET', True)),
                   int(d.getVar('FLASH_KERNEL_OFFSET', True)))
 
@@ -240,7 +241,7 @@ do_mk_static_symlinks() {
 	# Maintain non-standard legacy links
 	ln -sf ${IMAGE_NAME}.static.mtd ${IMGDEPLOYDIR}/flash-${MACHINE}
 	ln -sf ${IMAGE_NAME}.static.mtd ${IMGDEPLOYDIR}/image-bmc
-	ln -sf u-boot.${UBOOT_SUFFIX} ${IMGDEPLOYDIR}/image-u-boot
+	ln -sf ${FLASH_UBOOT_IMAGE} ${IMGDEPLOYDIR}/image-u-boot
 	ln -sf ${FLASH_KERNEL_IMAGE} ${IMGDEPLOYDIR}/image-kernel
 	ln -sf ${IMAGE_LINK_NAME}.${IMAGE_BASETYPE} ${IMGDEPLOYDIR}/image-rofs
 	ln -sf rwfs.${OVERLAY_BASETYPE} ${IMGDEPLOYDIR}/image-rwfs
@@ -296,7 +297,7 @@ make_image_links() {
 
 	# Create some links to help make the tar archive in the format
 	# expected by phosphor-bmc-code-mgmt.
-	ln -sf ${DEPLOY_DIR_IMAGE}/u-boot.${UBOOT_SUFFIX} image-u-boot
+	ln -sf ${DEPLOY_DIR_IMAGE}/${FLASH_UBOOT_IMAGE} image-u-boot
 	ln -sf ${DEPLOY_DIR_IMAGE}/${FLASH_KERNEL_IMAGE} image-kernel
 	ln -sf ${IMGDEPLOYDIR}/${IMAGE_LINK_NAME}.$rofs image-rofs
 	ln -sf rwfs.$rwfs image-rwfs

--- a/classes/image_types_phosphor.bbclass
+++ b/classes/image_types_phosphor.bbclass
@@ -145,7 +145,7 @@ do_generate_ubi[dirs] = "${S}/ubi"
 do_generate_ubi[depends] += " \
         ${PN}:do_image_${@d.getVar('FLASH_UBI_BASETYPE', True).replace('-', '_')} \
         virtual/kernel:do_deploy \
-        u-boot:do_populate_sysroot \
+        virtual/bootloader:do_populate_sysroot \
         mtd-utils-native:do_populate_sysroot \
         "
 
@@ -180,7 +180,7 @@ do_make_ubi[dirs] = "${S}/ubi"
 do_make_ubi[depends] += " \
         ${PN}:do_image_${@d.getVar('FLASH_UBI_BASETYPE', True).replace('-', '_')} \
         virtual/kernel:do_deploy \
-        u-boot:do_populate_sysroot \
+        virtual/bootloader:do_populate_sysroot \
         mtd-utils-native:do_populate_sysroot \
         "
 
@@ -250,7 +250,7 @@ do_generate_static[dirs] = "${S}/static"
 do_generate_static[depends] += " \
         ${PN}:do_image_${@d.getVar('IMAGE_BASETYPE', True).replace('-', '_')} \
         virtual/kernel:do_deploy \
-        u-boot:do_populate_sysroot \
+        virtual/bootloader:do_populate_sysroot \
         "
 
 make_signatures() {
@@ -331,7 +331,7 @@ do_generate_static_tar[dirs] = " ${S}/static"
 do_generate_static_tar[depends] += " \
         ${PN}:do_image_${@d.getVar('IMAGE_BASETYPE', True).replace('-', '_')} \
         virtual/kernel:do_deploy \
-        u-boot:do_populate_sysroot \
+        virtual/bootloader:do_populate_sysroot \
         openssl-native:do_populate_sysroot \
         ${SIGNING_KEY_DEPENDS} \
         ${PN}:do_copy_signing_pubkey \
@@ -349,7 +349,7 @@ do_generate_ubi_tar[dirs] = " ${S}/ubi"
 do_generate_ubi_tar[depends] += " \
         ${PN}:do_image_${@d.getVar('FLASH_UBI_BASETYPE', True).replace('-', '_')} \
         virtual/kernel:do_deploy \
-        u-boot:do_populate_sysroot \
+        virtual/bootloader:do_populate_sysroot \
         openssl-native:do_populate_sysroot \
         ${SIGNING_KEY_DEPENDS} \
         ${PN}:do_copy_signing_pubkey \


### PR DESCRIPTION
Currently the bootloader used when generating the flash image is hardcoded to u-boot. However  some boards need u-boot to be wrapped in another loader, or yet another loader might be used. Extend the phosphor image type to allow setting the bootloader image name, and use virtual/bootloader instead of u-boot for the dependency.